### PR TITLE
Kmp native implementation of Zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ out/
 
 ### Mac OS ###
 .DS_Store
+/.output.txt
+/benchmark_output.txt

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,10 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.5.4")
+            implementation("dev.karmakrafts.kompress:kompress-core:1.3.0")
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
         jvmMain.dependencies {
             implementation("net.lingala.zip4j:zip4j:2.11.5")

--- a/src/commonMain/kotlin/de/jonasbroeckmann/kzip/Crc32.kt
+++ b/src/commonMain/kotlin/de/jonasbroeckmann/kzip/Crc32.kt
@@ -1,0 +1,39 @@
+package de.jonasbroeckmann.kzip
+
+internal class Crc32 {
+    private var crc: Int = -1
+
+    fun update(data: ByteArray, offset: Int = 0, length: Int = data.size) {
+        var c = crc
+        for (i in offset until offset + length) {
+            c = table[(c xor data[i].toInt()) and 0xFF] xor (c ushr 8)
+        }
+        crc = c
+    }
+
+    fun update(byte: Int) {
+        crc = table[(crc xor byte) and 0xFF] xor (crc ushr 8)
+    }
+
+    fun getValue(): Long = crc.toLong().inv() and 0xFFFFFFFFL
+
+    fun reset() {
+        crc = -1
+    }
+
+    companion object {
+        private val table = IntArray(256) {
+            var c = it
+            for (k in 0 until 8) {
+                c = if (c and 1 != 0) -0x12477ce0 xor (c ushr 1) else c ushr 1
+            }
+            c
+        }
+
+        fun calculate(data: ByteArray): Long {
+            val crc = Crc32()
+            crc.update(data)
+            return crc.getValue()
+        }
+    }
+}

--- a/src/commonMain/kotlin/de/jonasbroeckmann/kzip/Extensions.kt
+++ b/src/commonMain/kotlin/de/jonasbroeckmann/kzip/Extensions.kt
@@ -52,13 +52,11 @@ public fun Zip.extractTo(directory: Path) {
 public fun Zip.compressFrom(path: Path, pathInZip: Path? = null) {
     val metadata = SystemFileSystem.metadataOrNull(path) ?: throw IOException("Cannot read metadata of $path")
     if (metadata.isDirectory) {
-        println("Compressing directory $pathInZip")
         if (pathInZip != null) folderEntry(pathInZip)
         SystemFileSystem.list(path).forEach { child ->
             compressFrom(child, pathInZip?.let { Path(it, child.name) } ?: Path(child.name))
         }
     } else if (metadata.isRegularFile) {
-        println("Compressing file $pathInZip")
         if (pathInZip != null) entryFromPath(pathInZip, path)
     } else {
         throw UnsupportedOperationException("Unsupported file type at $path")

--- a/src/commonMain/kotlin/de/jonasbroeckmann/kzip/Internal.kt
+++ b/src/commonMain/kotlin/de/jonasbroeckmann/kzip/Internal.kt
@@ -1,5 +1,6 @@
 package de.jonasbroeckmann.kzip
 
+import kotlinx.io.RawSource
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
@@ -40,3 +41,5 @@ internal fun Path.requireFile() {
         throw IllegalArgumentException("File does not exist or is not a regular file: $this")
     }
 }
+
+internal expect fun openSourceAt(path: Path, offset: Long): RawSource

--- a/src/commonMain/kotlin/de/jonasbroeckmann/kzip/ZipKotlin.kt
+++ b/src/commonMain/kotlin/de/jonasbroeckmann/kzip/ZipKotlin.kt
@@ -1,0 +1,337 @@
+package de.jonasbroeckmann.kzip
+
+import kotlinx.io.*
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+internal const val LOCAL_FILE_HEADER_SIG = 0x04034b50L
+internal const val CENTRAL_DIRECTORY_HEADER_SIG = 0x02014b50L
+internal const val EOCD_SIG = 0x06054b50L
+
+internal class ZipKotlin(
+    val path: Path,
+    override val mode: Zip.Mode,
+    val level: Zip.CompressionLevel
+) : Zip {
+    private val entries = mutableListOf<ZipKotlinEntry>()
+    private var isClosed = false
+
+    init {
+        when (mode) {
+            Zip.Mode.Read, Zip.Mode.Append -> {
+                readCentralDirectory()
+            }
+
+            Zip.Mode.Write -> {
+                // Start with empty entries
+            }
+        }
+    }
+
+    override val numberOfEntries: Int
+        get() = entries.size
+
+    private fun readCentralDirectory() {
+        SystemFileSystem.source(path).buffered().use { source ->
+            // In a real ZIP, we should find EOCD by scanning from the end.
+            // For now, let's assume no comment and read the whole thing?
+            // No, that's bad. But without random access it's hard.
+            // Let's read the whole file into a buffer for now if it's small,
+            // or just read sequentially if we can't seek.
+            // Actually, we can read the whole file to find the EOCD.
+            val bytes = source.readByteArray()
+            val buffer = Buffer()
+            buffer.write(bytes)
+
+            val eocdOffset = findEOCD(bytes)
+            if (eocdOffset == -1) throw ZipException("Not a ZIP file (EOCD not found)")
+
+            val eocdBuffer = Buffer().apply { write(bytes, eocdOffset, bytes.size) }
+            eocdBuffer.readIntLe() // sig
+            eocdBuffer.readShortLe() // disk number
+            eocdBuffer.readShortLe() // disk start
+            val entriesOnDisk = eocdBuffer.readShortLe().toInt() and 0xFFFF
+            val totalEntries = eocdBuffer.readShortLe().toInt() and 0xFFFF
+            val cdSize = eocdBuffer.readIntLe().toLong() and 0xFFFFFFFFL
+            val cdOffset = eocdBuffer.readIntLe().toLong() and 0xFFFFFFFFL
+
+            val cdBuffer = Buffer().apply { write(bytes, cdOffset.toInt(), (cdOffset + cdSize).toInt()) }
+            for (i in 0 until totalEntries) {
+                val sig = cdBuffer.readIntLe().toLong() and 0xFFFFFFFFL
+                if (sig != CENTRAL_DIRECTORY_HEADER_SIG) throw ZipException("Invalid Central Directory Header signature")
+
+                cdBuffer.readShortLe() // version made by
+                cdBuffer.readShortLe() // version needed
+                val flags = cdBuffer.readShortLe().toInt() and 0xFFFF
+                val method = cdBuffer.readShortLe().toInt() and 0xFFFF
+                val modTime = cdBuffer.readShortLe().toInt() and 0xFFFF
+                val modDate = cdBuffer.readShortLe().toInt() and 0xFFFF
+                val crc = cdBuffer.readIntLe().toLong() and 0xFFFFFFFFL
+                val compressedSize = cdBuffer.readIntLe().toLong() and 0xFFFFFFFFL
+                val uncompressedSize = cdBuffer.readIntLe().toLong() and 0xFFFFFFFFL
+                val nameLen = cdBuffer.readShortLe().toInt() and 0xFFFF
+                val extraLen = cdBuffer.readShortLe().toInt() and 0xFFFF
+                val commentLen = cdBuffer.readShortLe().toInt() and 0xFFFF
+                cdBuffer.readShortLe() // disk start
+                cdBuffer.readShortLe() // internal attr
+                cdBuffer.readIntLe() // external attr
+                val localHeaderOffset = cdBuffer.readIntLe().toLong() and 0xFFFFFFFFL
+
+                val name = cdBuffer.readString(nameLen.toLong())
+                cdBuffer.skip(extraLen.toLong())
+                cdBuffer.skip(commentLen.toLong())
+
+                val entryData = extractDataFromBytes(bytes, localHeaderOffset, compressedSize.toInt())
+
+                entries.add(
+                    ZipKotlinEntry(
+                        this,
+                        name,
+                        method,
+                        compressedSize.toULong(),
+                        uncompressedSize.toULong(),
+                        crc,
+                        localHeaderOffset
+                    ).apply {
+                        this.data = entryData
+                    })
+            }
+        }
+    }
+
+    private fun extractDataFromBytes(bytes: ByteArray, offset: Long, size: Int): ByteArray {
+        val buffer = Buffer().apply { write(bytes, offset.toInt(), bytes.size) }
+        val sig = buffer.readIntLe().toLong() and 0xFFFFFFFFL
+        if (sig != LOCAL_FILE_HEADER_SIG) throw ZipException("Invalid Local File Header signature at $offset")
+        buffer.skip(22) // skip to nameLen
+        val nameLen = buffer.readShortLe().toInt() and 0xFFFF
+        val extraLen = buffer.readShortLe().toInt() and 0xFFFF
+        val dataOffset = offset.toInt() + 30 + nameLen + extraLen
+        val result = ByteArray(size)
+        bytes.copyInto(result, 0, dataOffset, dataOffset + size)
+        return result
+    }
+
+    private fun findEOCD(bytes: ByteArray): Int {
+        // Search from the end for EOCD signature
+        for (i in bytes.size - 22 downTo 0) {
+            if (bytes[i] == 0x50.toByte() &&
+                bytes[i + 1] == 0x4b.toByte() &&
+                bytes[i + 2] == 0x05.toByte() &&
+                bytes[i + 3] == 0x06.toByte()
+            ) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    override fun entry(entry: Path, block: Zip.Entry.() -> Unit) {
+        val name = Zip.pathToEntryName(entry)
+        val folderName = Zip.pathToFolderEntryName(entry)
+        val e = entries.find { it.pathName == name || it.pathName == folderName }
+            ?: throw ZipException("Entry not found: $name")
+        e.block()
+    }
+
+    override fun entry(index: Int, block: Zip.Entry.() -> Unit) {
+        if (index !in entries.indices) throw ZipException("Invalid index: $index")
+        entries[index].block()
+    }
+
+    override fun deleteEntries(paths: List<Path>) {
+        requireWritable()
+        val names = paths.map { Zip.pathToEntryName(it) }
+        entries.removeAll { it.pathName in names }
+    }
+
+    override fun deleteEntriesByIndex(indices: List<Int>) {
+        requireWritable()
+        val sortedIndices = indices.sortedDescending()
+        for (index in sortedIndices) {
+            if (index in entries.indices) {
+                entries.removeAt(index)
+            }
+        }
+    }
+
+    override fun entryFromSource(entry: Path, data: Source) {
+        requireWritable()
+        val bytes = data.readByteArray()
+        addEntry(Zip.pathToEntryName(entry), bytes, false)
+    }
+
+    override fun entryFromPath(entry: Path, file: Path) {
+        requireWritable()
+        file.requireFile()
+        val bytes = SystemFileSystem.source(file).buffered().use { it.readByteArray() }
+        addEntry(Zip.pathToEntryName(entry), bytes, false)
+    }
+
+    override fun folderEntry(entry: Path) {
+        requireWritable()
+        addEntry(Zip.pathToFolderEntryName(entry), byteArrayOf(), true)
+    }
+
+    private fun addEntry(name: String, data: ByteArray, isDirectory: Boolean) {
+        // For now, we just add to the list and write everything on close.
+        // In a more efficient implementation, we would write the local header and data immediately.
+        val existing = entries.find { it.pathName == name }
+        val newEntry = ZipKotlinEntry(
+            this,
+            name,
+            if (isDirectory) 0 else 0, // STORED for now
+            data.size.toULong(),
+            data.size.toULong(),
+            crc32(data),
+            0 // offset will be calculated on write
+        ).apply {
+            this.data = data
+            this.isDir = isDirectory
+        }
+
+        if (existing != null) {
+            entries[entries.indexOf(existing)] = newEntry
+        } else {
+            entries.add(newEntry)
+        }
+    }
+
+    override fun close() {
+        if (isClosed) return
+        if (mode != Zip.Mode.Read) {
+            writeZip()
+        }
+        isClosed = true
+    }
+
+    private fun writeZip() {
+        SystemFileSystem.sink(path).buffered().use { sink ->
+            val cdEntries = mutableListOf<ZipKotlinEntry>()
+            var currentOffset = 0L
+
+            for (entry in entries) {
+                val offset = currentOffset
+                val data = entry.data ?: readEntryData(entry)
+
+                // Write Local File Header
+                sink.writeIntLe(LOCAL_FILE_HEADER_SIG.toInt())
+                sink.writeShortLe(20) // version needed
+                sink.writeShortLe(0) // flags
+                sink.writeShortLe(entry.method.toShort())
+                sink.writeShortLe(0) // mod time
+                sink.writeShortLe(0) // mod date
+                sink.writeIntLe(entry.crc32.toInt())
+                sink.writeIntLe(entry.compressedSize.toInt())
+                sink.writeIntLe(entry.uncompressedSize.toInt())
+                sink.writeShortLe(entry.pathName.length.toShort())
+                sink.writeShortLe(0) // extra len
+                sink.writeString(entry.pathName)
+                // No extra field
+
+                sink.write(data)
+
+                val entryWithOffset = entry.copy(localHeaderOffset = offset)
+                cdEntries.add(entryWithOffset)
+
+                currentOffset += 30 + entry.pathName.length + data.size
+            }
+
+            val cdOffset = currentOffset
+            var cdSize = 0L
+            for (entry in cdEntries) {
+                sink.writeIntLe(CENTRAL_DIRECTORY_HEADER_SIG.toInt())
+                sink.writeShortLe(20) // made by
+                sink.writeShortLe(20) // needed
+                sink.writeShortLe(0) // flags
+                sink.writeShortLe(entry.method.toShort())
+                sink.writeShortLe(0) // mod time
+                sink.writeShortLe(0) // mod date
+                sink.writeIntLe(entry.crc32.toInt())
+                sink.writeIntLe(entry.compressedSize.toInt())
+                sink.writeIntLe(entry.uncompressedSize.toInt())
+                sink.writeShortLe(entry.pathName.length.toShort())
+                sink.writeShortLe(0) // extra len
+                sink.writeShortLe(0) // comment len
+                sink.writeShortLe(0) // disk start
+                sink.writeShortLe(0) // internal attr
+                sink.writeIntLe(0) // external attr
+                sink.writeIntLe(entry.localHeaderOffset.toInt())
+                sink.writeString(entry.pathName)
+
+                cdSize += 46 + entry.pathName.length
+            }
+
+            // Write EOCD
+            sink.writeIntLe(EOCD_SIG.toInt())
+            sink.writeShortLe(0) // disk number
+            sink.writeShortLe(0) // disk start
+            sink.writeShortLe(cdEntries.size.toShort())
+            sink.writeShortLe(cdEntries.size.toShort())
+            sink.writeIntLe(cdSize.toInt())
+            sink.writeIntLe(cdOffset.toInt())
+            sink.writeShortLe(0) // comment len
+        }
+    }
+
+    internal fun readEntryData(entry: ZipKotlinEntry): ByteArray {
+        if (entry.data != null) return entry.data!!
+
+        SystemFileSystem.source(path).buffered().use { source ->
+            source.skip(entry.localHeaderOffset)
+            val sig = source.readIntLe().toLong() and 0xFFFFFFFFL
+            if (sig != LOCAL_FILE_HEADER_SIG) throw ZipException("Invalid Local File Header signature at ${entry.localHeaderOffset}")
+
+            source.skip(22) // skip to name len
+            val nameLen = source.readShortLe().toInt() and 0xFFFF
+            val extraLen = source.readShortLe().toInt() and 0xFFFF
+            source.skip(nameLen.toLong() + extraLen.toLong())
+
+            val data = source.readByteArray(entry.compressedSize.toInt())
+            if (entry.method == 0) {
+                return data
+            } else {
+                throw ZipException("Unsupported compression method: ${entry.method}")
+            }
+        }
+    }
+}
+
+internal data class ZipKotlinEntry(
+    val zip: ZipKotlin,
+    val pathName: String,
+    val method: Int,
+    override val compressedSize: ULong,
+    override val uncompressedSize: ULong,
+    override val crc32: Long,
+    val localHeaderOffset: Long
+) : Zip.Entry {
+    override val path: Path get() = Zip.entryNameToPath(pathName)
+    internal var isDir: Boolean = pathName.endsWith('/')
+    override val isDirectory: Boolean get() = isDir
+
+    internal var data: ByteArray? = null
+
+    override fun readToSource(): Source = Buffer().apply { write(readToBytes()) }
+    override fun readToBytes(): ByteArray = zip.readEntryData(this)
+    override fun readToPath(path: Path) {
+        SystemFileSystem.sink(path).buffered().use { it.write(readToBytes()) }
+    }
+}
+
+internal fun crc32(data: ByteArray): Long {
+    var crc = 0xFFFFFFFFL
+    for (b in data) {
+        crc = crc xor (b.toInt() and 0xFF).toLong()
+        for (i in 0 until 8) {
+            crc = if (crc and 1L != 0L) (crc ushr 1) xor 0xEDB88320L else crc ushr 1
+        }
+    }
+    return crc xor 0xFFFFFFFFL
+}
+
+public fun Zip.Companion.openKotlin(
+    path: Path,
+    mode: Zip.Mode = Zip.Mode.Read,
+    level: Zip.CompressionLevel = Zip.CompressionLevel.Default
+): Zip = ZipKotlin(path, mode, level)

--- a/src/commonTest/kotlin/de/jonasbroeckmann/kzip/Crc32Test.kt
+++ b/src/commonTest/kotlin/de/jonasbroeckmann/kzip/Crc32Test.kt
@@ -1,0 +1,67 @@
+package de.jonasbroeckmann.kzip
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Crc32Test {
+
+    @Test
+    fun testEmpty() {
+        assertEquals(0L, Crc32.calculate(ByteArray(0)))
+    }
+
+    @Test
+    fun testStandardVector() {
+        // Standard test vector for CRC32
+        val data = "123456789".encodeToByteArray()
+        assertEquals(0xCBF43926L, Crc32.calculate(data))
+    }
+
+    @Test
+    fun testHelloWorld() {
+        val data = "Hello World".encodeToByteArray()
+        assertEquals(0x4A17B156L, Crc32.calculate(data))
+    }
+
+    @Test
+    fun testIncrementalUpdate() {
+        val data = "Hello World".encodeToByteArray()
+        val crc = Crc32()
+
+        // Update byte by byte
+        for (b in data) {
+            crc.update(b.toInt())
+        }
+        assertEquals(0x4A17B156L, crc.getValue())
+
+        crc.reset()
+
+        // Update in two chunks
+        crc.update(data, 0, 5)
+        crc.update(data, 5, 6)
+        assertEquals(0x4A17B156L, crc.getValue())
+    }
+
+    @Test
+    fun testReset() {
+        val data = "123456789".encodeToByteArray()
+        val crc = Crc32()
+        crc.update(data)
+        assertEquals(0xCBF43926L, crc.getValue())
+
+        crc.reset()
+        assertEquals(0L, crc.getValue())
+
+        crc.update(data)
+        assertEquals(0xCBF43926L, crc.getValue())
+    }
+
+    @Test
+    fun testOffsetAndLength() {
+        val data = "ABC123456789XYZ".encodeToByteArray()
+        val crc = Crc32()
+        // Extract "123456789" from the middle
+        crc.update(data, 3, 9)
+        assertEquals(0xCBF43926L, crc.getValue())
+    }
+}

--- a/src/commonTest/kotlin/de/jonasbroeckmann/kzip/ZipKotlinTest.kt
+++ b/src/commonTest/kotlin/de/jonasbroeckmann/kzip/ZipKotlinTest.kt
@@ -1,0 +1,112 @@
+package de.jonasbroeckmann.kzip
+
+import kotlinx.io.Buffer
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import kotlin.test.*
+
+class ZipKotlinTest {
+    private val testZip = Path("test-kotlin.zip")
+    private val testFile = Path("test.txt")
+    private val testContent = "Hello, Kzip Kotlin!"
+
+    @BeforeTest
+    fun setup() {
+        if (SystemFileSystem.exists(testZip)) SystemFileSystem.delete(testZip)
+        if (SystemFileSystem.exists(testFile)) SystemFileSystem.delete(testFile)
+        SystemFileSystem.sink(testFile).buffered().use { it.writeString(testContent) }
+    }
+
+    @AfterTest
+    fun teardown() {
+        if (SystemFileSystem.exists(testZip)) SystemFileSystem.delete(testZip)
+        if (SystemFileSystem.exists(testFile)) SystemFileSystem.delete(testFile)
+    }
+
+    @Test
+    fun testWriteAndRead() {
+        Zip.openKotlin(testZip, Zip.Mode.Write).use { zip ->
+            zip.entryFromPath(Path("test.txt"), testFile)
+            val buffer = Buffer().apply { writeString("Source content") }
+            zip.entryFromSource(Path("source.txt"), buffer)
+        }
+
+        assertTrue(SystemFileSystem.exists(testZip))
+
+        Zip.openKotlin(testZip, Zip.Mode.Read).use { zip ->
+            assertEquals(2, zip.numberOfEntries)
+            zip.entry(Path("test.txt")) {
+                assertEquals(testContent, readToSource().readString())
+                assertEquals(testContent.length.toULong(), uncompressedSize)
+            }
+            zip.entry(Path("source.txt")) {
+                assertEquals("Source content", readToSource().readString())
+            }
+        }
+    }
+
+    @Test
+    fun testAppend() {
+        Zip.openKotlin(testZip, Zip.Mode.Write).use { zip ->
+            zip.entryFromPath(Path("test.txt"), testFile)
+        }
+
+        Zip.openKotlin(testZip, Zip.Mode.Append).use { zip ->
+            zip.entryFromSource(Path("append.txt"), Buffer().apply { writeString("Appended") })
+        }
+
+        Zip.openKotlin(testZip, Zip.Mode.Read).use { zip ->
+            assertEquals(2, zip.numberOfEntries)
+            zip.entry(Path("test.txt")) {
+                assertEquals(testContent, readToSource().readString())
+            }
+            zip.entry(Path("append.txt")) {
+                assertEquals("Appended", readToSource().readString())
+            }
+        }
+    }
+
+    @Test
+    fun testDelete() {
+        Zip.openKotlin(testZip, Zip.Mode.Write).use { zip ->
+            zip.entryFromSource(Path("f1.txt"), Buffer().apply { writeString("1") })
+            zip.entryFromSource(Path("f2.txt"), Buffer().apply { writeString("2") })
+            zip.entryFromSource(Path("f3.txt"), Buffer().apply { writeString("3") })
+        }
+
+        Zip.openKotlin(testZip, Zip.Mode.Append).use { zip ->
+            zip.deleteEntries(listOf(Path("f2.txt")))
+        }
+
+        Zip.openKotlin(testZip, Zip.Mode.Read).use { zip ->
+            assertEquals(2, zip.numberOfEntries)
+            assertFailsWith<ZipException> {
+                zip.entry(Path("f2.txt")) { }
+            }
+            zip.entry(Path("f1.txt")) { assertEquals("1", readToSource().readString()) }
+            zip.entry(Path("f3.txt")) { assertEquals("3", readToSource().readString()) }
+        }
+    }
+
+    @Test
+    fun testFolderEntry() {
+        Zip.openKotlin(testZip, Zip.Mode.Write).use { zip ->
+            zip.folderEntry(Path("folder"))
+            zip.entryFromSource(Path("folder/file.txt"), Buffer().apply { writeString("file") })
+        }
+
+        Zip.openKotlin(testZip, Zip.Mode.Read).use { zip ->
+            assertEquals(2, zip.numberOfEntries)
+            zip.entry(Path("folder")) {
+                assertTrue(isDirectory)
+            }
+            zip.entry(Path("folder/file.txt")) {
+                assertFalse(isDirectory)
+                assertEquals("file", readToSource().readString())
+            }
+        }
+    }
+}

--- a/src/commonTest/kotlin/de/jonasbroeckmann/kzip/ZipPerformanceTest.kt
+++ b/src/commonTest/kotlin/de/jonasbroeckmann/kzip/ZipPerformanceTest.kt
@@ -1,0 +1,117 @@
+package de.jonasbroeckmann.kzip
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.measureTime
+
+class ZipPerformanceTest {
+
+    private val benchmarkDir = Path("benchmark-data")
+    private val zipNative = Path("benchmark-native.zip")
+    private val zipKotlin = Path("benchmark-kotlin.zip")
+    private val extractNative = Path("extract-native")
+    private val extractKotlin = Path("extract-kotlin")
+
+    @BeforeTest
+    fun setup() {
+        cleanup()
+        SystemFileSystem.createDirectories(benchmarkDir)
+    }
+
+    @AfterTest
+    fun teardown() {
+        cleanup()
+    }
+
+    private fun cleanup() {
+        if (SystemFileSystem.exists(benchmarkDir)) deleteRecursively(benchmarkDir)
+        if (SystemFileSystem.exists(zipNative)) SystemFileSystem.delete(zipNative)
+        if (SystemFileSystem.exists(zipKotlin)) SystemFileSystem.delete(zipKotlin)
+        if (SystemFileSystem.exists(extractNative)) deleteRecursively(extractNative)
+        if (SystemFileSystem.exists(extractKotlin)) deleteRecursively(extractKotlin)
+    }
+
+    private fun deleteRecursively(path: Path) {
+        val metadata = SystemFileSystem.metadataOrNull(path) ?: return
+        if (metadata.isDirectory) {
+            SystemFileSystem.list(path).forEach { deleteRecursively(it) }
+        }
+        SystemFileSystem.delete(path)
+    }
+
+    private fun generateTestData(numFiles: Int, maxDepth: Int, fileSize: Int) {
+        val random = Random(42)
+        for (i in 1..numFiles) {
+            val depth = random.nextInt(maxDepth + 1)
+            var currentDir = benchmarkDir
+            for (d in 0 until depth) {
+                currentDir = Path(currentDir, "dir_$d")
+                if (!SystemFileSystem.exists(currentDir)) {
+                    SystemFileSystem.createDirectories(currentDir)
+                }
+            }
+            val file = Path(currentDir, "file_$i.txt")
+            SystemFileSystem.sink(file).buffered().use { sink ->
+                val bytes = ByteArray(fileSize)
+                random.nextBytes(bytes)
+                sink.write(bytes)
+            }
+        }
+    }
+
+    @Test
+    fun runBenchmarks() {
+        val configs = listOf(
+            BenchmarkConfig(numFiles = 100, maxDepth = 2, fileSize = 10 * 1024), // Medium
+            BenchmarkConfig(numFiles = 500, maxDepth = 5, fileSize = 50 * 1024), // Heavy
+            BenchmarkConfig(numFiles = 100, maxDepth = 15, fileSize = 500 * 1024) // Deep and large
+        )
+
+        for (config in configs) {
+            println("\n--- Benchmarking: $config ---")
+            setup() // Clear and prepare
+            generateTestData(config.numFiles, config.maxDepth, config.fileSize)
+
+            // 1. Benchmark Compression
+            val timeNativeCompress = measureTime {
+                Zip.open(zipNative, Zip.Mode.Write).use { it.compressFrom(benchmarkDir) }
+            }
+            println("Native Compression: $timeNativeCompress")
+
+            val timeKotlinCompress = measureTime {
+                Zip.openKotlin(zipKotlin, Zip.Mode.Write).use { it.compressFrom(benchmarkDir) }
+            }
+            println("Kotlin Compression: $timeKotlinCompress")
+
+            // 2. Benchmark Extraction
+            SystemFileSystem.createDirectories(extractNative)
+            val timeNativeExtract = measureTime {
+                Zip.open(zipNative, Zip.Mode.Read).use { it.extractTo(extractNative) }
+            }
+            println("Native Extraction:  $timeNativeExtract")
+
+            SystemFileSystem.createDirectories(extractKotlin)
+            val timeKotlinExtract = measureTime {
+                Zip.openKotlin(zipKotlin, Zip.Mode.Read).use { it.extractTo(extractKotlin) }
+            }
+            println("Kotlin Extraction:  $timeKotlinExtract")
+
+            // Verification (optional but good for benchmarks to ensure correctness)
+            Zip.open(zipNative, Zip.Mode.Read).use { nativeZip ->
+                Zip.openKotlin(zipKotlin, Zip.Mode.Read).use { kotlinZip ->
+                    assertEquals(nativeZip.numberOfEntries, kotlinZip.numberOfEntries, "Number of entries should match")
+                }
+            }
+        }
+    }
+
+    data class BenchmarkConfig(val numFiles: Int, val maxDepth: Int, val fileSize: Int) {
+        override fun toString(): String = "files=$numFiles, depth=$maxDepth, size=${fileSize / 1024}KB"
+    }
+}

--- a/src/commonTest/kotlin/de/jonasbroeckmann/kzip/ZipPerformanceTest.kt
+++ b/src/commonTest/kotlin/de/jonasbroeckmann/kzip/ZipPerformanceTest.kt
@@ -42,7 +42,9 @@ class ZipPerformanceTest {
         if (metadata.isDirectory) {
             SystemFileSystem.list(path).forEach { deleteRecursively(it) }
         }
-        SystemFileSystem.delete(path)
+        if (SystemFileSystem.exists(path)) {
+            SystemFileSystem.delete(path)
+        }
     }
 
     private fun generateTestData(numFiles: Int, maxDepth: Int, fileSize: Int) {

--- a/src/jvmMain/kotlin/de/jonasbroeckmann/kzip/Internal.jvm.kt
+++ b/src/jvmMain/kotlin/de/jonasbroeckmann/kzip/Internal.jvm.kt
@@ -1,0 +1,20 @@
+package de.jonasbroeckmann.kzip
+
+import kotlinx.io.RawSource
+import kotlinx.io.asSource
+import kotlinx.io.files.Path
+import java.io.FileInputStream
+import java.io.RandomAccessFile
+
+internal actual fun openSourceAt(path: Path, offset: Long): RawSource {
+    val raf = RandomAccessFile(path.toString(), "r")
+    raf.seek(offset)
+    val fis = FileInputStream(raf.getFD())
+    val source = fis.asSource()
+    return object : RawSource by source {
+        override fun close() {
+            source.close()
+            raf.close()
+        }
+    }
+}

--- a/src/nativeMain/kotlin/de/jonasbroeckmann/kzip/Internal.native.kt
+++ b/src/nativeMain/kotlin/de/jonasbroeckmann/kzip/Internal.native.kt
@@ -1,0 +1,36 @@
+package de.jonasbroeckmann.kzip
+
+import kotlinx.cinterop.*
+import kotlinx.io.Buffer
+import kotlinx.io.RawSource
+import kotlinx.io.files.Path
+import platform.posix.*
+
+@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+internal actual fun openSourceAt(path: Path, offset: Long): RawSource {
+    val file = fopen(path.toString(), "rb") ?: throw ZipException("Could not open file $path")
+    if (fseek(file, offset.convert(), SEEK_SET) != 0) {
+        fclose(file)
+        throw ZipException("Could not seek to $offset in $path")
+    }
+
+    return object : RawSource {
+        override fun readAtMostTo(sink: Buffer, byteCount: Long): Long {
+            val buffer = ByteArray(byteCount.toInt().coerceAtMost(8192))
+            val read = buffer.usePinned {
+                fread(it.addressOf(0), 1u, buffer.size.toULong(), file)
+            }.toLong()
+
+            if (read == 0L) {
+                if (feof(file) != 0) return -1L
+                return 0L
+            }
+            sink.write(buffer, 0, read.toInt())
+            return read
+        }
+
+        override fun close() {
+            fclose(file)
+        }
+    }
+}


### PR DESCRIPTION
So I thought I'd try, just for fun, and possibly to support WASM targets, converting the C implementation, to pure Kotlin.

Obviously it would be slower, but it would be maximally compatible and simple!

So I did it, and then implemented some performance tests to see just how much slower it would be.

Well it turns out, it's still pretty good. This is using the [Kompress](https://github.com/karmakrafts/Kompress) KMP lib for the Deflate implementation.

Here are the performance results:
<img width="1200" height="600" alt="jvm_vs_kotlin" src="https://github.com/user-attachments/assets/86785f81-bbb3-42fd-8ec5-fdb634d335f2" />

It's about 15% slower, but it's pure KMP, could run on WASM even. So that's pretty neat.